### PR TITLE
Update setup script to include more words

### DIFF
--- a/setup.js
+++ b/setup.js
@@ -36,20 +36,22 @@ db.serialize(function () {
             //Split the line to find relevant variables
             var sections = line.split(/\s+\|\s+/);
             var cols = sections[0].split(/\s/);
-            stmt.run(cols[4], sections[1], type);
+            cols = cols
+                .filter(col => col.match(/^[^\d!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^_`{|}~]/gm)) // doesn't start with number or special letter
+                .filter(col => col.length > 1); // has two or more charactors
+            cols.forEach(col => stmt.run(col, sections[1], type));
             rows++;
         });
-
 
         rl.on('close', function () {
             counter++;
             if (counter >= types.length) {
-                stmt.finalize();
-                db.run("END");
-                db.close();
+                stmt.finalize(()=>{
+                    db.run("END");
+                    db.exec("VACUUM");
+                    db.close();
+                });
             }
         });
     });
 });
-
-

--- a/setup.js
+++ b/setup.js
@@ -36,10 +36,16 @@ db.serialize(function () {
             //Split the line to find relevant variables
             var sections = line.split(/\s+\|\s+/);
             var cols = sections[0].split(/\s/);
-            cols = cols
+            var words = cols
                 .filter(col => col.match(/^[^\d!"#$%&'()\*\+\-\.,\/:;<=>?@\[\\\]^_`{|}~]/gm)) // doesn't start with number or special letter
                 .filter(col => col.length > 1); // has two or more charactors
-            cols.forEach(col => stmt.run(col, sections[1], type));
+
+            //Preserve cols[4] which always has a vaild meaning
+            if(words.indexOf(cols[4]) === -1){
+                words.push(cols[4])
+            }
+            
+            words.forEach(word => stmt.run(word, sections[1], type));
             rows++;
         });
 


### PR DESCRIPTION
Hi. Thanks for providing us a great project. I found it really useful for my work and here's a little change to make this even better.

In the course of generating a database, it used to include only the very first word and dropped several words that have the same meaning. Some of the essential vocabularies like "upcoming" had been dropped.

So I changed the code to add all of the elements of `cols` which start with an alphabet and have two or more characters.

Also I added some lines to run `VACUUM` to prevent database from getting too large.

This change increased the number of words from 117791 to 206797.

I would say it's definitely better to change the schema of the database in general, but I kept the structure for compatibility and usability.